### PR TITLE
Enhance spellcasters features

### DIFF
--- a/src/lib/components/AbilityScores/AbilityScores.svelte
+++ b/src/lib/components/AbilityScores/AbilityScores.svelte
@@ -38,7 +38,7 @@
 				<Ability abilityType="prof." bind:value={$abilityScores.proficiency} />
 			</li>
 			<div
-				class="xs:grid-cols-2 xs:gap-y-10 grid w-full flex-wrap justify-between gap-4 gap-x-2 md:flex md:gap-4"
+				class="grid w-full flex-wrap justify-between gap-4 gap-x-2 xs:grid-cols-2 xs:gap-y-10 md:flex md:gap-4"
 			>
 				{#each abilityTypes as t}
 					{#if t !== 'proficiency'}

--- a/src/lib/components/Spells/Spells.svelte
+++ b/src/lib/components/Spells/Spells.svelte
@@ -1,29 +1,39 @@
 <script lang="ts">
+	import { Label } from '$lib/components/ui/label';
+
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
+	import { Input } from '$lib/components/ui/input';
+	import { Switch } from '$lib/components/ui/switch';
 
 	import { Separator } from '$lib/components/ui/separator/index.js';
 
-	import { spells, type Spell, type SpellListKeys } from '$lib/stores/sheet';
+	import { spellcastingInfo, type Spell, type SpellListKeys } from '$lib/stores/sheet';
 
 	import AddIcon from '~icons/mdi/plus';
 	import SpellsIcon from '~icons/mdi/sparkles-outline';
 	import DeleteIcon from '~icons/mdi/trash-outline';
 
 	import { replaceFootToMeter } from '$lib/utils';
+	import Checkbox from '../ui/checkbox/checkbox.svelte';
+	import SpellcastingAttributes from './components/SpellcastingAttributes.svelte';
 	import SpellDescriptionDialog from './components/SpellDescriptionDialog.svelte';
 	import SpellsDialog from './components/SpellsDialog.svelte';
+	import SpellSlotSlider from './components/SpellSlotSlider.svelte';
 
+	let editMode = false;
 	let isOpen = false;
 	let isDescriptionOpen = false;
 	let selectedSpellDescription: Spell | null = null;
 
-	const levels: SpellListKeys[] = Object.keys($spells).map(Number);
+	const levels: SpellListKeys[] = Object.keys($spellcastingInfo.spellList).map(Number);
 
 	function handleDelete(spell: Spell) {
 		const level = spell.level as number;
-		$spells[level] = $spells[level].filter((s) => s.name !== spell.name);
+		$spellcastingInfo.spellList[level].spells = $spellcastingInfo.spellList[level].spells.filter(
+			(s) => s.name !== spell.name
+		);
 	}
 
 	function handleDescription(spell: Spell) {
@@ -31,7 +41,9 @@
 		isDescriptionOpen = true;
 	}
 
-	$: isSomeSpellSelected = levels.some((l) => $spells[l].length > 0);
+	$: isSomeSpellPrepared = levels.some((l) =>
+		$spellcastingInfo.spellList[l].spells.some((s) => editMode || s.prepared)
+	);
 </script>
 
 <Card.Root>
@@ -42,93 +54,121 @@
 				<span>Spells</span>
 			</Card.Title>
 		</div>
-		<Button class="!mt-0 p-2" variant="outline" on:click={() => (isOpen = true)}>
-			<AddIcon />
-		</Button>
+		<div class="!mt-0 flex items-center gap-4">
+			<Switch class="!mt-0" bind:checked={editMode} />
+			<Button class="!mt-0 p-2" variant="outline" on:click={() => (isOpen = true)}>
+				<AddIcon />
+			</Button>
+		</div>
 	</Card.Header>
 	<Card.Content>
-		<ul class="flex flex-col gap-4">
-			{#if isSomeSpellSelected}
+		<SpellcastingAttributes bind:editMode />
+
+		<ul class="mt-6 flex flex-col gap-4">
+			{#if isSomeSpellPrepared}
 				{#each levels as l}
-					{#if $spells[l].length > 0}
+					{#if $spellcastingInfo.spellList[l].spells.some((s) => editMode || s.prepared)}
 						<li>
-							<span class="font-semibold">
+							<div class={`flex flex-col gap-2 font-semibold`}>
 								{#if l === 0}
 									Cantrips
 								{:else}
-									Level {l}
-								{/if}
-							</span>
+									<span>Level {l}</span>
 
-							<Separator class="mb-2 mt-1" />
+									{#if editMode}
+										<div>
+											<Label class="font-semibold">Max slots:</Label>
+											<Input
+												class="w-fit"
+												type="number"
+												bind:value={$spellcastingInfo.spellList[l].slots.max}
+											/>
+										</div>
+									{:else}
+										<SpellSlotSlider
+											bind:value={$spellcastingInfo.spellList[l].slots.used}
+											max={$spellcastingInfo.spellList[l].slots.max}
+										/>
+									{/if}
+								{/if}
+							</div>
+
+							<Separator class="mb-2 mt-2" />
 
 							<ul class="flex flex-col gap-4">
-								{#each $spells[l] as spell}
-									<button class="cursor-pointer" on:click={() => handleDescription(spell)}>
-										<div class="flex items-center justify-between">
-											<span class="cursor-pointer font-semibold">{spell.name}</span>
-											<Button class="p-2" variant="ghost" on:click={() => handleDelete(spell)}>
-												<DeleteIcon />
-											</Button>
-										</div>
+								{#each $spellcastingInfo.spellList[l].spells.filter((s) => editMode || s.prepared) as spell}
+									<div class="flex items-center space-x-4">
+										{#if editMode}
+											<Checkbox bind:checked={spell.prepared} />
+										{/if}
 
-										<div
-											class="xs:gap-0 xs:items-center xs:flex-row flex flex-col justify-between gap-2 text-zinc-300"
-										>
-											<div class="flex gap-2">
-												<div class="flex items-center gap-1">
-													<Badge variant="secondary">{spell.casting_time}</Badge>
-												</div>
-												•
-												<!-- convert ft to m, rounded down -->
-												<div class="flex items-center gap-1">
-													<Badge variant="secondary">
-														<!-- {#if ['Self', 'Touch', 'Special', 'Unlimited', 'Sight'].some( (s) => spell.range.includes(s) )}
+										<button class="w-full cursor-pointer" on:click={() => handleDescription(spell)}>
+											<div class="flex items-center justify-between">
+												<span class="cursor-pointer font-normal">{spell.name}</span>
+												<Button class="p-2" variant="ghost" on:click={() => handleDelete(spell)}>
+													<DeleteIcon />
+												</Button>
+											</div>
+
+											<div
+												class="flex flex-col justify-between gap-2 text-zinc-300 xs:flex-row xs:items-center xs:gap-0"
+											>
+												<div class="flex gap-2">
+													<div class="flex items-center gap-1">
+														<Badge variant="secondary">{spell.casting_time}</Badge>
+													</div>
+													•
+													<!-- convert ft to m, rounded down -->
+													<div class="flex items-center gap-1">
+														<Badge variant="secondary">
+															<!-- {#if ['Self', 'Touch', 'Special', 'Unlimited', 'Sight'].some( (s) => spell.range.includes(s) )}
 															{replaceFootToMeter(spell.range)}
 														{:else}
 															{convertFeetToMeters(parseInt(spell.range))} m
 														{/if} -->
 
-														{replaceFootToMeter(spell.range)}
-													</Badge>
+															{replaceFootToMeter(spell.range)}
+														</Badge>
+													</div>
+
+													{#if spell.V || spell.S || spell.M !== undefined}
+														•
+														<div class="flex gap-1">
+															{#if spell.S}
+																<Badge variant="secondary">S</Badge>
+															{/if}
+															{#if spell.V}
+																<Badge variant="secondary">V</Badge>
+															{/if}
+															{#if spell.M !== undefined}
+																<Badge variant="secondary">M</Badge>
+															{/if}
+														</div>
+													{/if}
 												</div>
 
-												{#if spell.V || spell.S || spell.M !== undefined}
-													•
-													<div class="flex gap-1">
-														{#if spell.S}
-															<Badge variant="secondary">S</Badge>
+												{#if spell.concentration || spell.ritual}
+													<div class="flex gap-2">
+														{#if spell.concentration}
+															<Badge class="text-zinc-500" variant="outline">Concentration</Badge>
 														{/if}
-														{#if spell.V}
-															<Badge variant="secondary">V</Badge>
-														{/if}
-														{#if spell.M !== undefined}
-															<Badge variant="secondary">M</Badge>
+
+														{#if spell.ritual}
+															<Badge class="text-zinc-500" variant="outline">Ritual</Badge>
 														{/if}
 													</div>
 												{/if}
 											</div>
-
-											{#if spell.concentration || spell.ritual}
-												<div class="flex gap-2">
-													{#if spell.concentration}
-														<Badge class="text-zinc-500" variant="outline">Concentration</Badge>
-													{/if}
-
-													{#if spell.ritual}
-														<Badge class="text-zinc-500" variant="outline">Ritual</Badge>
-													{/if}
-												</div>
-											{/if}
-										</div>
-									</button>
+										</button>
+									</div>
 								{/each}
 							</ul>
 						</li>
+						<Separator class="mb-2 mt-2" />
 					{/if}
 				{/each}
 			{:else}
-				<span>No spells added.</span>
+				<span>No spells prepared.</span>
 			{/if}
 		</ul>
 	</Card.Content>

--- a/src/lib/components/Spells/components/SpellSlotSlider.svelte
+++ b/src/lib/components/Spells/components/SpellSlotSlider.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Slider } from '$lib/components/ui/slider/index.js';
+
+	export let value: number;
+	export let max;
+
+	let sliderValue = [value];
+
+	function handleChange(v: number[]) {
+		value = v[0];
+	}
+</script>
+
+<div>
+	<div class="flex max-w-80 gap-4">
+		<span class="font-normal">{value}</span>
+		<Slider onValueChange={handleChange} value={sliderValue} {max} step={1} class="max-w-[70%]" />
+		<span class="font-normal">{max}</span>
+	</div>
+</div>

--- a/src/lib/components/Spells/components/SpellcastingAttributes.svelte
+++ b/src/lib/components/Spells/components/SpellcastingAttributes.svelte
@@ -28,7 +28,7 @@
 	};
 </script>
 
-<div class="flex gap-6">
+<div class="gap-6 xs:flex">
 	<div class="flex flex-col gap-2">
 		<span class="font-semibold">Ability</span>
 		{#if editMode}

--- a/src/lib/components/Spells/components/SpellcastingAttributes.svelte
+++ b/src/lib/components/Spells/components/SpellcastingAttributes.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import * as Select from '$lib/components/ui/select/index.js';
+	import type { Selected } from 'bits-ui';
+
+	import { abilityScores, spellcastingInfo, type AbilityScoresKeys } from '$lib/stores/sheet';
+	import { getModifier, getSignedModifier } from '$lib/utils';
+
+	export let editMode = false;
+
+	let modifier: number, proficiency: number, saveDC: number, attackBonus: number;
+
+	function handleSelectedChange(selected: Selected<AbilityScoresKeys> | undefined): void {
+		if (!selected) return;
+
+		$spellcastingInfo.spellAbility = selected.value;
+	}
+
+	$: {
+		modifier = Number(getModifier($abilityScores[selected.value].score));
+		proficiency = Number($abilityScores.proficiency);
+		saveDC = 8 + modifier + proficiency;
+		attackBonus = modifier + proficiency;
+	}
+
+	$: selected = {
+		value: $spellcastingInfo.spellAbility,
+		label: $spellcastingInfo.spellAbility.toUpperCase()
+	};
+</script>
+
+<div class="flex gap-6">
+	<div class="flex flex-col gap-2">
+		<span class="font-semibold">Ability</span>
+		{#if editMode}
+			<div class="flex items-center gap-2">
+				<Select.Root bind:selected onSelectedChange={handleSelectedChange}>
+					<Select.Trigger class="flex w-fit px-4 py-5">
+						<Select.Value placeholder="Select an ability" />
+					</Select.Trigger>
+
+					<Select.Content>
+						<Select.Item value="strength">STRENGTH</Select.Item>
+						<Select.Item value="dexterity">DEXTERITY</Select.Item>
+						<Select.Item value="constitution">CONSTITUTION</Select.Item>
+						<Select.Item value="intelligence">INTELLIGENCE</Select.Item>
+						<Select.Item value="wisdom">WISDOM</Select.Item>
+						<Select.Item value="charisma">CHARISMA</Select.Item>
+					</Select.Content>
+				</Select.Root>
+
+				{getSignedModifier(modifier)}
+			</div>
+		{:else}
+			<span class="w-fit rounded-md border-[1px] px-4 py-2">
+				{selected.label.toUpperCase()}: {getSignedModifier(modifier)}
+			</span>
+		{/if}
+	</div>
+
+	<div class="flex flex-col gap-2">
+		<span class="font-semibold">Save DC</span>
+		<span class="w-fit rounded-md border-[1px] px-4 py-2">
+			{#if editMode}
+				8 {modifier >= 0 ? '+' : '-'} {Math.abs(modifier)} + {$abilityScores.proficiency}
+			{:else}
+				{getSignedModifier(saveDC)}
+			{/if}
+		</span>
+	</div>
+
+	<div class="flex flex-col gap-2">
+		<span class="font-semibold">Attack Bonus</span>
+		<span class="w-fit rounded-md border-[1px] px-4 py-2">
+			{#if editMode}
+				{Math.abs(modifier)} + {$abilityScores.proficiency}
+			{:else}
+				{getSignedModifier(attackBonus)}
+			{/if}
+		</span>
+	</div>
+</div>

--- a/src/lib/components/Spells/components/SpellsDialog.svelte
+++ b/src/lib/components/Spells/components/SpellsDialog.svelte
@@ -2,24 +2,28 @@
 	import spellsList from '$lib/assets/spells.json';
 
 	import Button from '$lib/components/ui/button/button.svelte';
+	import { Label } from '$lib/components/ui/label';
+
+	import { Checkbox } from '$lib/components/ui/checkbox';
 	import * as Command from '$lib/components/ui/command';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Popover from '$lib/components/ui/popover';
 
 	import SelectedIcon from '~icons/mdi/check';
 
-	import { spells, type Spell } from '$lib/stores/sheet';
+	import { spellcastingInfo, type Spell } from '$lib/stores/sheet';
 
 	export let isOpen = false;
 
 	let selectedSpell: Spell | null = null;
 	let open = false;
+	let prepared = true;
 
 	const SPELLS: Spell[] = spellsList;
 
 	function handleSelect(spell: string) {
 		const selected = SPELLS.find((s) => s.name === spell);
-		selectedSpell = selected as Spell;
+		selectedSpell = { ...selected } as Spell;
 		open = false;
 	}
 
@@ -28,9 +32,13 @@
 
 		const level = selectedSpell.level;
 
-		if ($spells[level].some((s) => s.name === selectedSpell?.name)) return;
+		if ($spellcastingInfo.spellList[level].spells.some((s) => s.name === selectedSpell?.name))
+			return;
 
-		$spells[level] = [...$spells[level], selectedSpell];
+		$spellcastingInfo.spellList[level].spells = [
+			...$spellcastingInfo.spellList[level].spells,
+			{ ...selectedSpell, prepared }
+		];
 	}
 
 	$: if (!isOpen) selectedSpell = null;
@@ -41,6 +49,11 @@
 		<Dialog.Header>
 			<Dialog.Title>Add new spell</Dialog.Title>
 		</Dialog.Header>
+
+		<div class="flex flex-col gap-2">
+			<Label for="prepared">Prepared:</Label>
+			<Checkbox id="prepared" bind:checked={prepared} />
+		</div>
 
 		<Popover.Root bind:open>
 			<Popover.Trigger>

--- a/src/lib/components/ui/slider/index.ts
+++ b/src/lib/components/ui/slider/index.ts
@@ -1,0 +1,7 @@
+import Root from "./slider.svelte";
+
+export {
+	Root,
+	//
+	Root as Slider,
+};

--- a/src/lib/components/ui/slider/slider.svelte
+++ b/src/lib/components/ui/slider/slider.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Slider as SliderPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = SliderPrimitive.Props;
+
+	let className: $$Props["class"] = undefined;
+	export let value: $$Props["value"] = [0];
+	export { className as class };
+</script>
+
+<SliderPrimitive.Root
+	bind:value
+	class={cn("relative flex w-full touch-none select-none items-center", className)}
+	{...$$restProps}
+	let:thumbs
+>
+	<span class="bg-primary/20 relative h-1.5 w-full grow overflow-hidden rounded-full">
+		<SliderPrimitive.Range class="bg-primary absolute h-full" />
+	</span>
+	{#each thumbs as thumb}
+		<SliderPrimitive.Thumb
+			{thumb}
+			class="border-primary/50 bg-background focus-visible:ring-ring block h-4 w-4 rounded-full border shadow transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
+		/>
+	{/each}
+</SliderPrimitive.Root>

--- a/src/lib/stores/sheet.ts
+++ b/src/lib/stores/sheet.ts
@@ -62,10 +62,17 @@ export type Spell = {
 	classes: string;
 	book: string;
 	id: number;
+	prepared?: boolean;
 };
 
 export type SpellList = {
-	[key: number]: Spell[];
+	[key: number]: {
+		slots: {
+			max: number;
+			used: number;
+		};
+		spells: Spell[];
+	};
 };
 
 interface Sheet {
@@ -77,6 +84,11 @@ interface Sheet {
 
 export type AbilityScoresKeys = keyof AbilityScores;
 export type SpellListKeys = keyof SpellList;
+
+interface SpellcastingInfo {
+	spellAbility: AbilityScoresKeys;
+	spellList: SpellList;
+}
 
 const defaultSkill: SkillType = {
 	proficiency: false,
@@ -178,15 +190,28 @@ export const stats: Writable<Stats> = writable({
 
 export const attacks: Writable<AttackType[]> = writable([]);
 
-export const spells: Writable<SpellList> = writable({
-	0: [],
-	1: [],
-	2: [],
-	3: [],
-	4: [],
-	5: [],
-	6: [],
-	7: [],
-	8: [],
-	9: []
+const defaultSpellLevel = {
+	slots: {
+		max: 0,
+		used: 0
+	},
+	spells: []
+};
+
+export const spellList: SpellList = {
+	0: { ...defaultSpellLevel, slots: { max: 0, used: 0 } },
+	1: { ...defaultSpellLevel, slots: { max: 0, used: 0 } },
+	2: { ...defaultSpellLevel, slots: { max: 0, used: 0 } },
+	3: { ...defaultSpellLevel, slots: { max: 0, used: 0 } },
+	4: { ...defaultSpellLevel, slots: { max: 0, used: 0 } },
+	5: { ...defaultSpellLevel, slots: { max: 0, used: 0 } },
+	6: { ...defaultSpellLevel, slots: { max: 0, used: 0 } },
+	7: { ...defaultSpellLevel, slots: { max: 0, used: 0 } },
+	8: { ...defaultSpellLevel, slots: { max: 0, used: 0 } },
+	9: { ...defaultSpellLevel, slots: { max: 0, used: 0 } }
+};
+
+export const spellcastingInfo: Writable<SpellcastingInfo> = writable({
+	spellAbility: 'intelligence',
+	spellList: { ...spellList }
 });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,7 +10,7 @@
 
 	import { ModeWatcher, toggleMode } from 'mode-watcher';
 
-	import { abilityScores, attacks, info, spells, stats } from '$lib/stores/sheet';
+	import { abilityScores, attacks, info, spellcastingInfo, stats } from '$lib/stores/sheet';
 	import { formatDate } from '$lib/utils';
 
 	let fileInput: HTMLInputElement;
@@ -26,7 +26,7 @@
 			abilityScores.set(sheet.abilityScores);
 			stats.set(sheet.stats);
 			attacks.set(sheet.attacks);
-			spells.set(sheet.spells);
+			spellcastingInfo.set(sheet.spellcastingInfo);
 		};
 
 		reader.readAsText(file);
@@ -38,7 +38,7 @@
 			abilityScores: $abilityScores,
 			stats: $stats,
 			attacks: $attacks,
-			spells: $spells
+			spellcastingInfo: $spellcastingInfo
 		};
 
 		const characterName = $info.characterName.trim().toLowerCase();
@@ -60,9 +60,9 @@
 <ModeWatcher />
 
 <header
-	class="xs:flex-row sticky top-0 z-[1] flex flex-col items-center justify-between gap-2 border-b-2 bg-white p-4 drop-shadow-sm dark:bg-zinc-950"
+	class="sticky top-0 z-[1] flex flex-col items-center justify-between gap-2 border-b-2 bg-white p-4 drop-shadow-sm dark:bg-zinc-950 xs:flex-row"
 >
-	<h1 class="xs:text-2xl font-bold">D&D Sheet</h1>
+	<h1 class="font-bold xs:text-2xl">D&D Sheet</h1>
 	<div class="flex gap-2">
 		<input class="hidden" type="file" bind:this={fileInput} on:change={handleFileSelect} />
 		<Button class="relative flex gap-2 p-2" variant="outline" on:click={toggleMode}>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,9 +6,9 @@
 <div class="my-2 flex flex-col gap-2 bg-inherit text-zinc-800">
 	<Info />
 
-	<div class="xs:grid flex flex-col gap-2 md:grid-cols-[auto_1fr]">
+	<div class="flex flex-col gap-2 xs:grid md:grid-cols-[auto_1fr]">
 		<AbilityScores />
-		<div class="flex flex-col gap-2">
+		<div class="space-y-2">
 			<Stats />
 			<Attacks />
 			<Spells />


### PR DESCRIPTION
Implements #2 

#### Spellcasting Attributes
- **Spellcasting Ability**: The ability (and modifier) used for casting rolls.
- **Spell Save DC**: Calculated as 8 + proficiency bonus + casting ability modifier.
- **Spell Attack Bonus**: Calculated as proficiency bonus + casting ability modifier.
- **Edit mode**: Add an edit mode in the spells panel to allow editing the attributes.

#### Spell Slots Tracking
- **Track Spell Slots**: On the spell levels header, add a section to track spell slots.
- **Prepared spells count**: On the spell levels header, shows the current prepared spells count for that level.
- **Edit mode**: In the spells panel edit mode, to allow editing the maximum slots for each level.

#### Prepared spells
- **Prepared checkbox**: When adding a new spell to the spells list, add a new attribute "prepared" to check if the user wants to make the spells prepared for the session; Not prepared spells will not be visible in the spells list/panel.
- **Edit mode**: In the spells panel edit mode, make **all known spells** visible and add the option for the user to prepare/unprepare spells at will.

#### Evidences
- View mode
![image](https://github.com/user-attachments/assets/a2d7a1b6-5a24-4873-8997-a185806f97d0)

- Edit mode
![image](https://github.com/user-attachments/assets/ae493e9f-d6ce-4069-9ef1-bb4ac222de9d)

- Spell dialog
![image](https://github.com/user-attachments/assets/a777b170-e0e6-44e3-8d49-6c4664628485)
