### PR TITLE
Add localStorage saving and other QoL

### DIFF
--- a/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { buttonVariants } from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = AlertDialogPrimitive.ActionProps;
+	type $$Events = AlertDialogPrimitive.ActionEvents;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<AlertDialogPrimitive.Action
+	class={cn(buttonVariants(), className)}
+	{...$$restProps}
+	on:click
+	on:keydown
+	let:builder
+>
+	<slot {builder} />
+</AlertDialogPrimitive.Action>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { buttonVariants } from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = AlertDialogPrimitive.CancelProps;
+	type $$Events = AlertDialogPrimitive.CancelEvents;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<AlertDialogPrimitive.Cancel
+	class={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
+	{...$$restProps}
+	on:click
+	on:keydown
+	let:builder
+>
+	<slot {builder} />
+</AlertDialogPrimitive.Cancel>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import * as AlertDialog from "./index.js";
+	import { cn, flyAndScale } from "$lib/utils.js";
+
+	type $$Props = AlertDialogPrimitive.ContentProps;
+
+	let className: $$Props["class"] = undefined;
+	export let transition: $$Props["transition"] = flyAndScale;
+	export let transitionConfig: $$Props["transitionConfig"] = undefined;
+	export { className as class };
+</script>
+
+<AlertDialog.Portal>
+	<AlertDialog.Overlay />
+	<AlertDialogPrimitive.Content
+		{transition}
+		{transitionConfig}
+		class={cn(
+			"bg-background fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg  sm:rounded-lg md:w-full",
+			className
+		)}
+		{...$$restProps}
+	>
+		<slot />
+	</AlertDialogPrimitive.Content>
+</AlertDialog.Portal>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = AlertDialogPrimitive.DescriptionProps;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<AlertDialogPrimitive.Description
+	class={cn("text-muted-foreground text-sm", className)}
+	{...$$restProps}
+>
+	<slot />
+</AlertDialogPrimitive.Description>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = HTMLAttributes<HTMLDivElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<div
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+	{...$$restProps}
+>
+	<slot />
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = HTMLAttributes<HTMLDivElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<div class={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...$$restProps}>
+	<slot />
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { fade } from "svelte/transition";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = AlertDialogPrimitive.OverlayProps;
+
+	let className: $$Props["class"] = undefined;
+	export let transition: $$Props["transition"] = fade;
+	export let transitionConfig: $$Props["transitionConfig"] = {
+		duration: 150,
+	};
+	export { className as class };
+</script>
+
+<AlertDialogPrimitive.Overlay
+	{transition}
+	{transitionConfig}
+	class={cn("bg-background/80 fixed inset-0 z-50 backdrop-blur-sm", className)}
+	{...$$restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	type $$Props = AlertDialogPrimitive.PortalProps;
+</script>
+
+<AlertDialogPrimitive.Portal {...$$restProps}>
+	<slot />
+</AlertDialogPrimitive.Portal>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	type $$Props = AlertDialogPrimitive.TitleProps;
+
+	let className: $$Props["class"] = undefined;
+	export let level: $$Props["level"] = "h3";
+	export { className as class };
+</script>
+
+<AlertDialogPrimitive.Title class={cn("text-lg font-semibold", className)} {level} {...$$restProps}>
+	<slot />
+</AlertDialogPrimitive.Title>

--- a/src/lib/components/ui/alert-dialog/index.ts
+++ b/src/lib/components/ui/alert-dialog/index.ts
@@ -1,0 +1,40 @@
+import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+import Title from "./alert-dialog-title.svelte";
+import Action from "./alert-dialog-action.svelte";
+import Cancel from "./alert-dialog-cancel.svelte";
+import Portal from "./alert-dialog-portal.svelte";
+import Footer from "./alert-dialog-footer.svelte";
+import Header from "./alert-dialog-header.svelte";
+import Overlay from "./alert-dialog-overlay.svelte";
+import Content from "./alert-dialog-content.svelte";
+import Description from "./alert-dialog-description.svelte";
+
+const Root = AlertDialogPrimitive.Root;
+const Trigger = AlertDialogPrimitive.Trigger;
+
+export {
+	Root,
+	Title,
+	Action,
+	Cancel,
+	Portal,
+	Footer,
+	Header,
+	Trigger,
+	Overlay,
+	Content,
+	Description,
+	//
+	Root as AlertDialog,
+	Title as AlertDialogTitle,
+	Action as AlertDialogAction,
+	Cancel as AlertDialogCancel,
+	Portal as AlertDialogPortal,
+	Footer as AlertDialogFooter,
+	Header as AlertDialogHeader,
+	Trigger as AlertDialogTrigger,
+	Overlay as AlertDialogOverlay,
+	Content as AlertDialogContent,
+	Description as AlertDialogDescription,
+};

--- a/src/lib/stores/sheet.ts
+++ b/src/lib/stores/sheet.ts
@@ -293,7 +293,11 @@ export function clearSheet() {
 
 export const unsavedChanges = writable(false);
 
-function saveToLocalStorage() {
+export function saveSheetToLocalStorage(sheet: Sheet) {
+	localStorage.setItem('sheet', JSON.stringify(sheet));
+}
+
+function autoSaveToLocalStorage() {
 	if (!browser) return;
 
 	const sheet = {
@@ -311,13 +315,13 @@ function saveToLocalStorage() {
 		return;
 	}
 
-	localStorage.setItem('sheet', JSON.stringify(sheet));
+	saveSheetToLocalStorage(sheet);
 
 	const isUnsaved = get(unsavedChanges);
 	if (!isUnsaved) unsavedChanges.set(true);
 }
 
-const saveToLocalStorageDebounced = debounce(saveToLocalStorage, 300);
+export const saveToLocalStorageDebounced = debounce(autoSaveToLocalStorage, 300);
 
 info.subscribe(saveToLocalStorageDebounced);
 abilityScores.subscribe(saveToLocalStorageDebounced);

--- a/src/lib/stores/sheet.ts
+++ b/src/lib/stores/sheet.ts
@@ -187,7 +187,7 @@ function getLocalStorageSheet() {
 	if (!sheet) return;
 
 	const parsedSheet = JSON.parse(sheet);
-	// lastSavedSheet.set({ ...parsedSheet });
+	lastSavedSheet.set(sheet);
 
 	return parsedSheet;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -88,3 +88,17 @@ export function formatDate(date: Date) {
 
 	return `${year}${month}${day}`;
 }
+
+export function debounce<T extends (...args: unknown[]) => unknown>(func: T, wait: number) {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+
+	return function (this: ThisParameterType<T>, ...args: Parameters<T>) {
+		const later = () => {
+			timeout = undefined;
+			func.apply(this, args);
+		};
+
+		clearTimeout(timeout);
+		timeout = setTimeout(later, wait);
+	};
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,26 +1,43 @@
 <script lang="ts">
 	import '../app.css';
 
+	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import { Button } from '$lib/components/ui/button';
 
 	import DarkModeIcon from '~icons/material-symbols/dark-mode';
 	import LightModeIcon from '~icons/material-symbols/light-mode';
+	import NewSheetIcon from '~icons/material-symbols/new-window';
 	import SaveIcon from '~icons/material-symbols/save-outline';
 	import LoadIcon from '~icons/mdi/file-outline';
 
 	import { ModeWatcher, toggleMode } from 'mode-watcher';
 
-	import { abilityScores, attacks, info, spellcastingInfo, stats } from '$lib/stores/sheet';
+	import {
+		abilityScores,
+		attacks,
+		clearSheet,
+		info,
+		lastSavedSheet,
+		spellcastingInfo,
+		stats,
+		unsavedChanges
+	} from '$lib/stores/sheet';
 	import { formatDate } from '$lib/utils';
 
 	let fileInput: HTMLInputElement;
+
+	let openLoadAlert = false;
+	let openNewSheetAlert = false;
 
 	function handleFileSelect(event: Event) {
 		const file = event.target?.files[0];
 		const reader = new FileReader();
 
 		reader.onload = function () {
-			const sheet = JSON.parse(reader.result as string);
+			const sheetString = reader.result as string;
+			const sheet = JSON.parse(sheetString);
+
+			lastSavedSheet.set(JSON.stringify(sheet));
 
 			info.set(sheet.info);
 			abilityScores.set(sheet.abilityScores);
@@ -54,26 +71,89 @@
 		a.href = url;
 		a.download = `${fileName}.json`;
 		a.click();
+
+		lastSavedSheet.set(JSON.stringify(sheet));
+		unsavedChanges.set(false);
+	}
+
+	function handleLoadSheetButtonClick() {
+		if ($unsavedChanges) {
+			openLoadAlert = true;
+			return;
+		}
+
+		fileInput.click();
+	}
+
+	function handleClearSheet() {
+		clearSheet();
+		openNewSheetAlert = false;
+	}
+
+	function handleNewSheet() {
+		if (!$unsavedChanges) {
+			handleClearSheet();
+			return;
+		}
+
+		openNewSheetAlert = true;
 	}
 </script>
 
 <ModeWatcher />
 
+<AlertDialog.Root bind:open={openLoadAlert}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Are you sure?</AlertDialog.Title>
+			<AlertDialog.Description>
+				There are unsaved changes. Loading a new sheet will discard all of them.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action on:click={() => fileInput.click()}>Continue</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
+<AlertDialog.Root bind:open={openNewSheetAlert}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Are you sure?</AlertDialog.Title>
+			<AlertDialog.Description>
+				You are about to discard all unsaved changes and start a new sheet. This action cannot be
+				undone.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action on:click={handleClearSheet}>Continue</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
 <header
 	class="sticky top-0 z-[1] flex flex-col items-center justify-between gap-2 border-b-2 bg-white p-4 drop-shadow-sm dark:bg-zinc-950 xs:flex-row"
 >
-	<h1 class="font-bold xs:text-2xl">D&D Sheet</h1>
-	<div class="flex gap-2">
+	<div class="flex gap-4">
+		<h1 class="font-bold xs:text-2xl">D&D Sheet</h1>
+		<Button class="flex gap-2 p-2" variant="outline" on:click={handleNewSheet}>
+			<NewSheetIcon />
+		</Button>
+	</div>
+	<div class="flex items-center gap-2">
 		<input class="hidden" type="file" bind:this={fileInput} on:change={handleFileSelect} />
 		<Button class="relative flex gap-2 p-2" variant="outline" on:click={toggleMode}>
 			<LightModeIcon class="absolute dark:scale-0" />
 			<DarkModeIcon class="scale-0 dark:scale-100" />
 		</Button>
-		<Button class="flex gap-2" variant="outline" on:click={() => fileInput.click()}>
+
+		<Button class="flex gap-2" variant="outline" on:click={handleLoadSheetButtonClick}>
 			<LoadIcon />
 			Load Sheet
 		</Button>
-		<Button class="flex gap-2" on:click={handleSave}>
+		<Button class={`flex gap-2 ${$unsavedChanges && 'bg-red-500'}`} on:click={handleSave}>
 			<SaveIcon />
 			Save
 		</Button>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
 		clearSheet,
 		info,
 		lastSavedSheet,
+		saveSheetToLocalStorage,
 		spellcastingInfo,
 		stats,
 		unsavedChanges
@@ -37,6 +38,7 @@
 			const sheetString = reader.result as string;
 			const sheet = JSON.parse(sheetString);
 
+			saveSheetToLocalStorage(sheet);
 			lastSavedSheet.set(JSON.stringify(sheet));
 
 			info.set(sheet.info);


### PR DESCRIPTION
### Implementation Details
Addresses #6 

- **LocalStorage Integration**:
  - ✅ Automatically saves the current state of the sheet to localStorage after each change **(debounced by 300ms)**.
  - ✅ Tracks the last explicitly saved state and highlights unsaved changes by turning the save button red.
    - This visual cue encourages users to manually save after completing changes, rather than relying solely on the auto-save feature.

- **Load from LocalStorage**:
  - ✅ On page load, checks for a saved state in localStorage and loads it, or starts with a new sheet if none is found.
  - ✅ Prompts the user to confirm before loading a new sheet if there are unsaved changes.

- **Start a New Sheet from Scratch**:
  - ✅ Added a "New Sheet" button in the header, allowing users to clear the current sheet from localStorage and start fresh.
  - ✅ Prompts the user to confirm before starting a new sheet if there are unsaved changes.


https://github.com/user-attachments/assets/49ef8a8a-6b00-41bd-b7c9-2c55e4b45ef5


